### PR TITLE
Added type definition to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,6 @@
 	"license" : "GPL-3.0+",
 	"keywords" : [
 		"ElasticPress Autosuggest Elasticsearch WordPress"
-	]
+	],
+	"type": "wordpress-plugin"
 }


### PR DESCRIPTION
Using composer with WordPress requires to have a `type: wordpress-plugin` set.
Ref #1 